### PR TITLE
allow progres to save its dbs to a custom location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 dist
 progres/trained_models/v*
 progres/databases/v*
+.vs
+.vscode

--- a/progres/progres.py
+++ b/progres/progres.py
@@ -40,6 +40,11 @@ trained_model_dir = os.path.join(data_dir, "trained_models", trained_model_subdi
 database_dir      = os.path.join(data_dir, "databases"     , database_subdir     )
 trained_model_fp  = os.path.join(trained_model_dir, "trained_model.pt")
 
+dirs_that_should_exist = [data_dir, trained_model_dir, database_dir]
+for dir in dirs_that_should_exist:
+    os.makedirs(dir, exist_ok=True)    
+
+
 class SinusoidalPositionalEncoding(torch.nn.Module):
     def __init__(self, channels):
         super().__init__()

--- a/progres/progres.py
+++ b/progres/progres.py
@@ -388,7 +388,7 @@ def download_data_if_required(download_afted=False):
                       sep="", file=sys.stderr)
                 printed = True
             if not printed:
-                print("Downloading data as first time setup (~220 MB) to ", progres_dir,
+                print("Downloading data as first time setup (~220 MB) to ", database_dir,
                       ", internet connection required, this can take a few minutes",
                       sep="", file=sys.stderr)
                 printed = True

--- a/progres/progres.py
+++ b/progres/progres.py
@@ -34,8 +34,10 @@ zenodo_record = "10975201" # This only needs to change when the trained model or
 trained_model_subdir = "v_0_2_0" # This only needs to change when the trained model changes
 database_subdir      = "v_0_2_1" # This only needs to change when the databases change
 progres_dir       = os.path.dirname(os.path.realpath(__file__))
-trained_model_dir = os.path.join(progres_dir, "trained_models", trained_model_subdir)
-database_dir      = os.path.join(progres_dir, "databases"     , database_subdir     )
+# allow data dir to be set from env var if exists, otherwise default to software location
+data_dir          = os.getenv('PROGRES_DATA_DIR', default=progres_dir)
+trained_model_dir = os.path.join(data_dir, "trained_models", trained_model_subdir)
+database_dir      = os.path.join(data_dir, "databases"     , database_subdir     )
 trained_model_fp  = os.path.join(trained_model_dir, "trained_model.pt")
 
 class SinusoidalPositionalEncoding(torch.nn.Module):


### PR DESCRIPTION
saving inside the installation dir of the program doesn't work in all contexts, e.g. in shared HPC environments when the software is set up centrally

It also helps for containerization to have the location separate.

This pull request should be fully backward compatible, it would only change the behavior when the user sets the env var PROGRES_DATA_DIR.

Hopefully contribs are welcome!

Cheers

J